### PR TITLE
Improve efficiency of casting complex numbers to complex vectors.

### DIFF
--- a/src/SIMDMath.jl
+++ b/src/SIMDMath.jl
@@ -11,6 +11,8 @@ module SIMDMath
 
 using Base: llvmcall, VecElement
 
+using Base.Cartesian: @ntuple
+
 export horner_simd, pack_poly
 export horner, pack_horner
 


### PR DESCRIPTION
Improves partly #8. Does not re-implement approaches but improves the efficiency of converting a tuple of complex numbers to complex vectors.

Before...

```julia
a = 1.1 + 1.3im
b = 1.1 + 1.6im
c = 2.1 + 1.6im
d = 2.1 + 1.9im

julia> @code_llvm debuginfo=:none ComplexVec((a, b, c, d))
define void @julia_ComplexVec_2450([2 x <4 x double>]* noalias nocapture sret([2 x <4 x double>]) %0, {}* nonnull readonly %1, [4 x [2 x double]]* nocapture nonnull readonly align 8 dereferenceable(64) %2) #0 {
top:
  %3 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 0, i64 0
  %4 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 0, i64 1
  %5 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 1, i64 0
  %6 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 1, i64 1
  %7 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 2, i64 0
  %8 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 2, i64 1
  %9 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 3, i64 0
  %10 = getelementptr inbounds [4 x [2 x double]], [4 x [2 x double]]* %2, i64 0, i64 3, i64 1
  %11 = load double, double* %3, align 8
  %12 = load double, double* %5, align 8
  %13 = load double, double* %7, align 8
  %14 = load double, double* %9, align 8
  %15 = insertelement <4 x double> undef, double %11, i32 0
  %16 = insertelement <4 x double> %15, double %12, i32 1
  %17 = insertelement <4 x double> %16, double %13, i32 2
  %18 = insertelement <4 x double> %17, double %14, i32 3
  %19 = load double, double* %4, align 8
  %20 = load double, double* %6, align 8
  %21 = load double, double* %8, align 8
  %22 = load double, double* %10, align 8
  %23 = insertelement <4 x double> undef, double %19, i32 0
  %24 = insertelement <4 x double> %23, double %20, i32 1
  %25 = insertelement <4 x double> %24, double %21, i32 2
  %26 = insertelement <4 x double> %25, double %22, i32 3
  %.sroa.0.0..sroa_idx = getelementptr inbounds [2 x <4 x double>], [2 x <4 x double>]* %0, i64 0, i64 0
  store <4 x double> %18, <4 x double>* %.sroa.0.0..sroa_idx, align 32
  %.sroa.2.0..sroa_idx1 = getelementptr inbounds [2 x <4 x double>], [2 x <4 x double>]* %0, i64 0, i64 1
  store <4 x double> %26, <4 x double>* %.sroa.2.0..sroa_idx1, align 32
  ret void


julia> @code_native debuginfo=:none ComplexVec((a, b, c, d))
	.section	__TEXT,__text,regular,pure_instructions
	.build_version macos, 11, 0
	.globl	_julia_ComplexVec_2452          ; -- Begin function julia_ComplexVec_2452
	.p2align	2
_julia_ComplexVec_2452:                 ; @julia_ComplexVec_2452
	.cfi_startproc
; %bb.0:                                ; %top
	add	x9, x1, #16                     ; =16
	add	x10, x1, #24                    ; =24
	add	x11, x1, #48                    ; =48
	add	x12, x1, #56                    ; =56
	ldp	d0, d1, [x1]
	ld1	{ v0.d }[1], [x9]
	ldp	d2, d3, [x1, #32]
	ld1	{ v2.d }[1], [x11]
	ld1	{ v1.d }[1], [x10]
	ld1	{ v3.d }[1], [x12]
	stp	q0, q2, [x8]
	stp	q1, q3, [x8, #32]
	ret
	.cfi_endproc
                                        ; -- End function
.subsections_via_symbols
```

After...
```julia
julia> @code_llvm debuginfo=:none SIMDMath.ComplexVec3((a, b, c, d))
define void @julia_ComplexVec3_2553([2 x <4 x double>]* noalias nocapture sret([2 x <4 x double>]) %0, [4 x [2 x double]]* nocapture nonnull readonly align 8 dereferenceable(64) %1) #0 {
top:
  %2 = bitcast [4 x [2 x double]]* %1 to <8 x double>*
  %3 = load <8 x double>, <8 x double>* %2, align 8
  %res.i = shufflevector <8 x double> %3, <8 x double> undef, <4 x i32> <i32 0, i32 2, i32 4, i32 6>
  %res.i2 = shufflevector <8 x double> %3, <8 x double> undef, <4 x i32> <i32 1, i32 3, i32 5, i32 7>
  %.sroa.0.0..sroa_idx = getelementptr inbounds [2 x <4 x double>], [2 x <4 x double>]* %0, i64 0, i64 0
  store <4 x double> %res.i, <4 x double>* %.sroa.0.0..sroa_idx, align 32
  %.sroa.2.0..sroa_idx1 = getelementptr inbounds [2 x <4 x double>], [2 x <4 x double>]* %0, i64 0, i64 1
  store <4 x double> %res.i2, <4 x double>* %.sroa.2.0..sroa_idx1, align 32
  ret void
}

julia> @code_native debuginfo=:none SIMDMath.ComplexVec3((a, b, c, d))
	.section	__TEXT,__text,regular,pure_instructions
	.build_version macos, 11, 0
	.globl	_julia_ComplexVec3_2577         ; -- Begin function julia_ComplexVec3_2577
	.p2align	2
_julia_ComplexVec3_2577:                ; @julia_ComplexVec3_2577
	.cfi_startproc
; %bb.0:                                ; %top
	ld2	{ v0.2d, v1.2d }, [x0], #32
	ld2	{ v2.2d, v3.2d }, [x0]
	stp	q0, q2, [x8]
	stp	q1, q3, [x8, #32]
	ret
	.cfi_endproc
                                        ; -- End function
.subsections_via_symbols
```