### PR TITLE
Add horizontal reduction

### DIFF
--- a/src/complex.jl
+++ b/src/complex.jl
@@ -82,3 +82,18 @@ end
 
 # conjugate
 @inline Base.conj(z::ComplexVec{N, FloatTypes}) where {N, FloatTypes} = ComplexVec{N, FloatTypes}(z.re, fneg(z.im))
+
+# horizontal reduction
+
+@inline reduce_fadd(z::ComplexVec{2, FloatTypes}) where FloatTypes = z[1] + z[2]
+
+@inline function reduce_fadd(z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
+    if ispow2(N)
+        a = ComplexVec(shufflevector(z.re, Val(0:N÷2-1)), shufflevector(z.im, Val(0:N÷2-1)))
+        b = ComplexVec(shufflevector(z.re, Val(N÷2:N-1)), shufflevector(z.im, Val(N÷2:N-1)))
+        c = fadd(a, b)
+        return reduce_fadd(c)
+    else
+        return sum(ntuple(i -> z[i], Val(N)))
+    end
+end

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -83,17 +83,28 @@ end
 # conjugate
 @inline Base.conj(z::ComplexVec{N, FloatTypes}) where {N, FloatTypes} = ComplexVec{N, FloatTypes}(z.re, fneg(z.im))
 
-# horizontal reduction
+# complex horizontal reduction
+@inline fhadd(z::ComplexVec{2, FloatTypes}) where FloatTypes = z[1] + z[2]
+@inline fhmul(z::ComplexVec{2, FloatTypes}) where FloatTypes = z[1] * z[2]
 
-@inline reduce_fadd(z::ComplexVec{2, FloatTypes}) where FloatTypes = z[1] + z[2]
-
-@inline function reduce_fadd(z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
+@inline function fhadd(z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
     if ispow2(N)
         a = ComplexVec(shufflevector(z.re, Val(0:N÷2-1)), shufflevector(z.im, Val(0:N÷2-1)))
         b = ComplexVec(shufflevector(z.re, Val(N÷2:N-1)), shufflevector(z.im, Val(N÷2:N-1)))
         c = fadd(a, b)
-        return reduce_fadd(c)
+        return fhadd(c)
     else
-        return sum(ntuple(i -> z[i], Val(N)))
+        return reduce(+, ntuple(i -> z[i], Val(N)))
+    end
+end
+
+@inline function fhmul(z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
+    if ispow2(N)
+        a = ComplexVec(shufflevector(z.re, Val(0:N÷2-1)), shufflevector(z.im, Val(0:N÷2-1)))
+        b = ComplexVec(shufflevector(z.re, Val(N÷2:N-1)), shufflevector(z.im, Val(N÷2:N-1)))
+        c = fmul(a, b)
+        return fhmul(c)
+    else
+        return reduce(*, ntuple(i -> z[i], Val(N)))
     end
 end

--- a/test/complex_test.jl
+++ b/test/complex_test.jl
@@ -71,6 +71,20 @@ let
     @test cconj[2] == conj(c[2])
 end
 
+# test horizontal reduction
+let 
+    for N in (2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 16, 17)
+        x = ntuple(i -> (complex(rand(), rand())), N)
+        xvec = ComplexVec(x)
+        @test sum(x) ≈ SIMDMath.fhadd(xvec)
+        @test reduce(*, x) ≈ SIMDMath.fhmul(xvec)
+
+        # test real case
+        @test sum(real.(x)) ≈ SIMDMath.fhadd(Vec(xvec.re))
+        @test reduce(*, real.(x)) ≈ SIMDMath.fhmul(Vec(xvec.re))
+    end
+end
+
 P1 = (1.1, 1.2, 1.4, 1.5, 1.3, 1.4, 1.5, 1.6, 1.7, 1.2, 1.2, 2.1, 3.1, 1.4, 1.5)
 P2 = (1.1, 1.2, 1.4, 1.53, 1.32, 1.41, 1.52, 1.64, 1.4, 1.0, 1.6, 2.5, 3.1, 1.9, 1.2)
 pp3 = pack_poly((P1, P2))


### PR DESCRIPTION
It's also convenient to sum a vector (horizontal add). This is in general not what you want to do at all and should be avoided. But generally this operation comes at the end of the algorithm.

LLVM offers this method explicitly which can be coded with something like..

```julia
@inline @generated function reduce_fadd(x::LVec{N, T}) where {N, T <: FloatTypes}
    ff = string("llvm.vector.reduce.fadd.v", N, T)
    s = """
    declare $(LLVMType[T]) @$ff($(LLVMType[T]), <$N x $(LLVMType[T])>)
    define $(LLVMType[T]) @entry(<$N x $(LLVMType[T])>) #0 {
    top:
        %1 = call reassoc $(LLVMType[T]) @$ff($(LLVMType[T]) -0.0, <$N x $(LLVMType[T])> %0)
        ret $(LLVMType[T]) %1
    }
    """
    return :(
        llvmcall($(s, "entry"), T, Tuple{LVec{N, T}}, x)
        )
end
```
The issue is that for some reason LLVM is really slow. Even with the `reassoc` flag it doesn't seem to implement optimal reduction. 

For example, here is the reduction of a real vector of length 16 using the llvm reduction.
```julia
julia> @benchmark SIMDMath.reduce_fadd3($a.data)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.666 ns … 13.833 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.750 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.767 ns ±  0.235 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

             ▃           █          ▆           ▂            ▁
  ▃▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█ █
  3.67 ns      Histogram: log(frequency) by time     3.88 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

And here is the reduction of a COMPLEX vector of length 16 using this method.

```julia
julia> @benchmark SIMDMath.reduce_fadd($a)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.708 ns … 28.041 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.833 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.834 ns ±  0.371 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                         ▇          █           ▂          ▁ ▁
  ▃▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█ █
  2.71 ns      Histogram: log(frequency) by time     2.92 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

It doesn't seem like much of course but it's also doing double the amount of work. 

Anyway, I've gone with two different implementations. An optimal approach if the length of the vector is a power of two and then a fallback approach to just summing them up if not a power of two. This I think is ok because your vectors should generally be as wide as the register width so we will usually always hit the optimimal path. Of course, this method assumes that the order can be summed in any way. This is the general assumption we make with the whole library.

Going to update with new name and add the real version