### PR TITLE
Potentially add vector dot product?

### DIFF
--- a/src/SIMDMath.jl
+++ b/src/SIMDMath.jl
@@ -23,5 +23,6 @@ include("intrinsics.jl")
 include("interface.jl")
 include("complex.jl")
 include("horner.jl")
+include("linearalgebra.jl")
 
 end

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -82,6 +82,7 @@ end
 
 # conjugate
 @inline Base.conj(z::ComplexVec{N, FloatTypes}) where {N, FloatTypes} = ComplexVec{N, FloatTypes}(z.re, fneg(z.im))
+@inline Base.conj(z::Vec{N, FloatTypes}) where {N, FloatTypes} = z
 
 # complex horizontal reduction
 @inline fhadd(z::ComplexVec{2, FloatTypes}) where FloatTypes = z[1] + z[2]

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -1,0 +1,53 @@
+function dot(x::NTuple{N, Complex{T}}, y::NTuple{N, Complex{T}}) where {N, T}
+    R = N % 4
+
+    if R == 0
+        _x = constantvector(zero(Complex{T}), ComplexVec{4, T})
+        _y = constantvector(zero(Complex{T}), ComplexVec{4, T})
+    elseif R == 1
+        _x = ComplexVec((x[1], zero(Complex{T}), zero(Complex{T}), zero(Complex{T})))
+        _y = ComplexVec((y[1], zero(Complex{T}), zero(Complex{T}), zero(Complex{T})))
+    elseif R == 2
+        _x = ComplexVec((x[1], x[2], zero(Complex{T}), zero(Complex{T})))
+        _y = ComplexVec((y[1], y[2], zero(Complex{T}), zero(Complex{T})))
+    elseif R == 3
+        _x = ComplexVec((x[1], x[2], x[3], zero(Complex{T})))
+        _y = ComplexVec((y[1], y[2], y[3], zero(Complex{T})))
+    end
+
+    out = fmul(conj(_x), _y)
+
+    for i in R+1:4:length(x)
+        a = ComplexVec((x[i], x[i+1], x[i+2], x[i+3]))
+        b = ComplexVec((y[i], y[i+1], y[i+2], y[i+3]))
+        out = fmadd(conj(a), b, out)
+    end
+    return fhadd(out)
+end
+
+function dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T}
+    R = N % 4
+
+    if R == 0
+        _x = constantvector(zero(T), Vec{4, T})
+        _y = constantvector(zero(T), Vec{4, T})
+    elseif R == 1
+        _x = Vec((x[1], zero(T), zero(T), zero(T)))
+        _y = Vec((y[1], zero(T), zero(T), zero(T)))
+    elseif R == 2
+        _x = Vec((x[1], x[2], zero(T), zero(T)))
+        _y = Vec((y[1], y[2], zero(T), zero(T)))
+    elseif R == 3
+        _x = Vec((x[1], x[2], x[3], zero(T)))
+        _y = Vec((y[1], y[2], y[3], zero(T)))
+    end
+
+    out = fmul(_x, _y)
+
+    for i in R+1:4:length(x)
+        a = Vec((x[i], x[i+1], x[i+2], x[i+3]))
+        b = Vec((y[i], y[i+1], y[i+2], y[i+3]))
+        out = fmadd(a, b, out)
+    end
+    return fhadd(out)
+end

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -1,43 +1,20 @@
-function dot(x::NTuple{N, Complex{T}}, y::NTuple{N, Complex{T}}) where {N, T}
-    R = N % 4
+dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, Val(8))
+dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T} = dot(x, y, Val(4))
 
-    if R == 0
-        _x = constantvector(zero(Complex{T}), ComplexVec{4, T})
-        _y = constantvector(zero(Complex{T}), ComplexVec{4, T})
-    elseif R == 1
-        _x = ComplexVec((x[1], zero(Complex{T}), zero(Complex{T}), zero(Complex{T})))
-        _y = ComplexVec((y[1], zero(Complex{T}), zero(Complex{T}), zero(Complex{T})))
-    elseif R == 2
-        _x = ComplexVec((x[1], x[2], zero(Complex{T}), zero(Complex{T})))
-        _y = ComplexVec((y[1], y[2], zero(Complex{T}), zero(Complex{T})))
-    elseif R == 3
-        _x = ComplexVec((x[1], x[2], x[3], zero(Complex{T})))
-        _y = ComplexVec((y[1], y[2], y[3], zero(Complex{T})))
-    end
-
-    out = fmul(conj(_x), _y)
-
-    for i in R+1:4:length(x)
-        a = ComplexVec((x[i], x[i+1], x[i+2], x[i+3]))
-        b = ComplexVec((y[i], y[i+1], y[i+2], y[i+3]))
-        out = fmadd(conj(a), b, out)
-    end
-    return fhadd(out)
-end
-
-function dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T}
-    unroll = 32
+function dot(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
+    V = T <: Real ? Vec : ComplexVec
+    unroll = M
     R = N % unroll
 
-    _x = Vec((ntuple(i -> x[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...))
-    _y = Vec((ntuple(i -> y[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...))
+    _x = (ntuple(i -> x[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...)
+    _y = (ntuple(i -> y[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...)
   
-    out = fmul(_x, _y)
+    out = fmul(conj(V(_x)), V(_y))
 
     for i in R+1:unroll:length(x)
-        a = Vec(ntuple(k -> x[i + k - 1], Val(unroll)))
-        b = Vec(ntuple(k -> y[i + k - 1], Val(unroll)))
-        out = fmadd(a, b, out)
+        a = ntuple(k -> x[i + k - 1], Val(unroll))
+        b = ntuple(k -> y[i + k - 1], Val(unroll))
+        out = fmadd(conj(V(a)), V(b), out)
     end
     return fhadd(out)
 end


### PR DESCRIPTION
Motivated a little bit by the question in slack on computing dot products of complex vectors. I don't really want this library to be a blas type of thing as I'd like to keep it lightweight and support the needs of Bessels but I also understand that this library is now very well suited for these type of things and I think the only SIMD library to explicitly support complex SIMD vectors.

Anyway, it is of course exceptionally easy to beat the base linear algebra routines..

```julia
 x = ntuple(i -> (complex(rand(), rand())), 4*50 + 3);
 y = ntuple(i -> (complex(rand(), rand())), 4*50 + 3);
xr = real.(x);
yr = real.(y);

julia> @benchmark SIMDMath.dot($x, $y)
BenchmarkTools.Trial: 10000 samples with 952 evaluations.
 Range (min … max):  96.988 ns … 137.780 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     97.120 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   97.437 ns ±   1.879 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅█▅▃                             ▁▃                          ▁
  ████▇▆▅▄▅▄▄▃▄▃▃▃▅▃▃▄▃▄▄▁▃▄▁▁▃▃▁▃███▇▅▃▃▄▄▃▄▄▁▄▄▄▅▆▆▅▆▆▆▅▃▃▁▃ █
  97 ns         Histogram: log(frequency) by time       102 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark LinearAlgebra.dot($x, $y)
BenchmarkTools.Trial: 10000 samples with 714 evaluations.
 Range (min … max):  176.471 ns … 236.636 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     176.646 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   177.269 ns ±   3.263 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▆                ▂▄                                          ▁
  ███▆▅▅▅▅▅▅▅▆▅▆▁▁▁▆██▅▅▅▄▃▄▆▅▆█▇▇▃▃▁▄▄▁▁▄▁▁▁▁▁▃▃▃▁▃▃▄▁▁▃▁▄▃▁▃▃ █
  176 ns        Histogram: log(frequency) by time        189 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark SIMDMath.dot($xr, $yr)
BenchmarkTools.Trial: 10000 samples with 994 evaluations.
 Range (min … max):  31.607 ns … 66.230 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     31.732 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   31.837 ns ±  1.018 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▁█▃                                                         
  ▃███▄▃▂▂▂▂▁▂▂▁▁▁▂▂▁▁▁▁▂▂▂▂▂▁▁▂▁▁▁▂▁▂▁▁▂▁▁▂▁▁▁▁▂▁▁▁▁▂▁▁▂▂▂▂▂ ▂
  31.6 ns         Histogram: frequency by time        34.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark LinearAlgebra.dot($xr, $yr)
BenchmarkTools.Trial: 10000 samples with 792 evaluations.
 Range (min … max):  159.197 ns … 234.164 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     159.564 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   160.135 ns ±   2.923 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▄█▄                    ▃▂                                    ▁
  ▃███▇▅▆▃▃▅▃▅▆▇▅▆▅▄▃▄▁▄▄███▆▅▃▄▄▄▅▄▅▆▇▆▇▇▄▅▅▃▁▃▃▃▄▁▁▄▁▄▅▅▄▄▄▅▅ █
  159 ns        Histogram: log(frequency) by time        169 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

So 1.8x faster for complex dot products and 5x faster for real dot products. And this is just on my apple to support 2x wide simd. 

It might be better to also look at Float32 to fit more numbers in...
```julia
julia> x32 = ComplexF32.(x);

julia> y32 = ComplexF32.(y);

julia> @benchmark LinearAlgebra.dot($x32, $y32)
BenchmarkTools.Trial: 10000 samples with 719 evaluations.
 Range (min … max):  176.751 ns … 254.811 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     176.925 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   177.815 ns ±   3.427 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▇▁             ▂▄                                       ▂    ▂
  ███▇▆▆▇▅▆▆▄▆▅▄▁▄███▅▅▅▅▆▆▇▇██▆▅▁▅▄▄▄▅▅▃▄▁▄▅▄▃▃▁▃▅▃▃▃▁▃▁▁▄█▇▆▅ █
  177 ns        Histogram: log(frequency) by time        191 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark SIMDMath.dot($x32, $y32)
BenchmarkTools.Trial: 10000 samples with 987 evaluations.
 Range (min … max):  49.856 ns … 83.249 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     49.983 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   50.158 ns ±  1.244 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅█▅▃                                ▂                       ▁
  ████▇▄▁▄▁▁▃▁▃▄▄▄▁▅▄▃▃▁▄▅▃▃▃▁▃▁▄▃▁▁▆██▅▅▄▃▁▄▄▃▁▄▄▃▁▁▄▆▅▅▅▅▆▄ █
  49.9 ns      Histogram: log(frequency) by time      54.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

# for reals
julia> xr32 = ComplexF32.(xr);

julia> yr32 = ComplexF32.(yr);

julia> @benchmark LinearAlgebra.dot($xr32, $yr32)
BenchmarkTools.Trial: 10000 samples with 714 evaluations.
 Range (min … max):  176.703 ns … 241.539 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     176.880 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   177.596 ns ±   3.281 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▆▂               ▁▄▁                                         ▁
  ███▆▆▄▄▄▅▃▆▅▆▅▃▄▁▅███▅▁▃▄▄▅▅▆▇▇▇█▅▄▁▃▁▄▄▄▁▃▁▁▃▃▅▅▆▆▆▅▄▅▄▄▁▄▁▄ █
  177 ns        Histogram: log(frequency) by time        189 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark SIMDMath.dot($xr32, $yr32)
BenchmarkTools.Trial: 10000 samples with 988 evaluations.
 Range (min … max):  49.848 ns … 91.051 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     49.975 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   50.173 ns ±  1.564 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃█▆▃▂                                   ▂                   ▁
  █████▅▃▃▄▁▁▁▁▁▃▄▁▁▃▃▃▃▃▁▃▅▄▄▁▁▁▃▁▁▁▁▁▃▇▇█▇▁▅▃▁▃▃▃▄▄▁▃▄▅▄▄▅▅ █
  49.8 ns      Histogram: log(frequency) by time      54.1 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

So now ComplexF32 is 3.2x faster. This should scale better AVX and AVX-512 of course to see much more speed ups. But I'll have to adjust the SIMD width a little bit. I'm away from my AVX computer so Ill have to do that later.

This also beats BLAS pretty convincingly as well. Of course we are unrolling everything so that helps beat it.