### PR TITLE
Improve complex multiply add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+/test/Manifest.toml

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -120,6 +120,8 @@ end
 @inline Base.conj(z::Vec{N, FloatTypes}) where {N, FloatTypes} = z
 
 # complex horizontal reduction
+@inline fhadd(z::ComplexVec{1, FloatTypes}) where FloatTypes = z[1]
+@inline fhmul(z::ComplexVec{1, FloatTypes}) where FloatTypes = z[1]
 @inline fhadd(z::ComplexVec{2, FloatTypes}) where FloatTypes = z[1] + z[2]
 @inline fhmul(z::ComplexVec{2, FloatTypes}) where FloatTypes = z[1] * z[2]
 

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -63,6 +63,14 @@ end
 # a*b + c
 @inline fmadd(x, y, z) = fadd(fmul(x, y), z)
 
+@inline function fmadd(x::ComplexVec{N, FloatTypes}, y::ComplexVec{N, FloatTypes}, z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmadd(x.re, y.re, z.re)
+    i = fmadd(x.re, y.im, z.im)
+    i = fmadd(x.im, y.re, i)
+    r = fnmadd(x.im, y.im, r)
+    return ComplexVec(r, i)
+end
+
 # complex multiply-subtract
 # a*b - c
 @inline fmsub(x, y, z) = fsub(fmul(x, y), z)

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -101,6 +101,24 @@ end
     i = fmadd(x.im, y.re, i)
     return ComplexVec(r, i)
 end
+@inline function fmsub(x::ComplexVec{N, FloatTypes}, y::ComplexVec{N, FloatTypes}, z::Vec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmsub(x.re, y.re, z.data)
+    i = fmul(x.re, y.im)
+    r = fnmadd(x.im, y.im, r)
+    i = fmadd(x.im, y.re, i)
+    return ComplexVec(r, i)
+end
+@inline function fmsub(x::ComplexVec{N, FloatTypes}, y::Vec{N, FloatTypes}, z::Vec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmsub(x.re, y.data, z.data)
+    i = fmul(x.im, y.data)
+    return ComplexVec(r, i)
+end
+@inline function fmsub(x::ComplexVec{N, FloatTypes}, y::Vec{N, FloatTypes}, z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmsub(x.re, y.data, z.re)
+    i = fmsub(x.im, y.data, z.im)
+    return ComplexVec(r, i)
+end
+@inline fmsub(x::Vec{N, FloatTypes}, y::ComplexVec{N, FloatTypes}, z) where {N, FloatTypes} = fmsub(y, x, z)
 
 # complex negated multiply-add
 # -a*b + c

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -66,14 +66,41 @@ end
 @inline function fmadd(x::ComplexVec{N, FloatTypes}, y::ComplexVec{N, FloatTypes}, z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
     r = fmadd(x.re, y.re, z.re)
     i = fmadd(x.re, y.im, z.im)
-    i = fmadd(x.im, y.re, i)
     r = fnmadd(x.im, y.im, r)
+    i = fmadd(x.im, y.re, i)
     return ComplexVec(r, i)
 end
+@inline function fmadd(x::ComplexVec{N, FloatTypes}, y::ComplexVec{N, FloatTypes}, z::Vec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmadd(x.re, y.re, z.data)
+    i = fmul(x.re, y.im)
+    r = fnmadd(x.im, y.im, r)
+    i = fmadd(x.im, y.re, i)
+    return ComplexVec(r, i)
+end
+@inline function fmadd(x::ComplexVec{N, FloatTypes}, y::Vec{N, FloatTypes}, z::Vec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmadd(x.re, y.data, z.data)
+    i = fmul(x.im, y.data)
+    return ComplexVec(r, i)
+end
+@inline function fmadd(x::ComplexVec{N, FloatTypes}, y::Vec{N, FloatTypes}, z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmadd(x.re, y.data, z.re)
+    i = fmadd(x.im, y.data, z.im)
+    return ComplexVec(r, i)
+end
+
+@inline fmadd(x::Vec{N, FloatTypes}, y::ComplexVec{N, FloatTypes}, z) where {N, FloatTypes} = fmadd(y, x, z)
 
 # complex multiply-subtract
 # a*b - c
 @inline fmsub(x, y, z) = fsub(fmul(x, y), z)
+
+@inline function fmsub(x::ComplexVec{N, FloatTypes}, y::ComplexVec{N, FloatTypes}, z::ComplexVec{N, FloatTypes}) where {N, FloatTypes}
+    r = fmsub(x.re, y.re, z.re)
+    i = fmsub(x.re, y.im, z.im)
+    r = fnmadd(x.im, y.im, r)
+    i = fmadd(x.im, y.re, i)
+    return ComplexVec(r, i)
+end
 
 # complex negated multiply-add
 # -a*b + c

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -39,6 +39,8 @@ Base.@propagate_inbounds function Base.getindex(v::ComplexVec{N, T}, i::IntegerT
 end
 
 # horizontal reduction
+@inline fhadd(z::Vec{1, FloatTypes}) where FloatTypes = z[1]
+@inline fhmul(z::Vec{1, FloatTypes}) where FloatTypes = z[1]
 @inline fhadd(z::Vec{2, FloatTypes}) where FloatTypes = z[1] + z[2]
 @inline fhmul(z::Vec{2, FloatTypes}) where FloatTypes = z[1] * z[2]
 

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -1,7 +1,36 @@
-@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, Val(8))
-@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T} = dot(x, y, Val(4))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, Val(16))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float32, ComplexF32}} = dot(x, y, Val(8))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float64, ComplexF64}} = dot(x, y, Val(4))
 
 @inline function dot(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
+    V = T <: Real ? Vec : ComplexVec
+    unroll = M
+    R = N % (2*unroll)
+
+    s1 = V(ntuple(i -> zero(T), Val(M)))
+    s2 = V(ntuple(i -> zero(T), Val(M)))
+
+    for i in 1:2*unroll:N-R
+        a = ntuple(k -> x[i + k - 1], Val(unroll))
+        b = ntuple(k -> y[i + k - 1], Val(unroll))
+        c = ntuple(k -> x[i + k - 1 + unroll], Val(unroll))
+        d = ntuple(k -> y[i + k - 1 + unroll], Val(unroll))
+
+        s1 = fmadd(conj(V(a)), V(b), s1)
+        s2 = fmadd(conj(V(c)), V(d), s2)
+    end
+   
+    s = fhadd(fadd(s1, s2))
+    if !iszero(R)
+        _x = ntuple(i -> x[N - R + i], Val(R))
+        _y = ntuple(i -> y[N - R + i], Val(R))
+        s3 = fmul(conj(V(_x)), V(_y))
+        s += fhadd(s3)
+    end
+    return s
+end
+
+@inline function dot2(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
     V = T <: Real ? Vec : ComplexVec
     unroll = M
     R = N % unroll

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -1,6 +1,6 @@
-@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, Val(16))
-@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float32, ComplexF32}} = dot(x, y, Val(8))
-@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float64, ComplexF64}} = dot(x, y, Val(4))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, N < 64 ? Val(8) : Val(16))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float32, ComplexF32}} = dot(x, y, N < 64 ? Val(4) : Val(8))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float64, ComplexF64}} = dot(x, y, N < 64 ? Val(2) : Val(4))
 
 @inline function dot(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
     V = T <: Real ? Vec : ComplexVec
@@ -28,22 +28,4 @@
         s += fhadd(s3)
     end
     return s
-end
-
-@inline function dot2(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
-    V = T <: Real ? Vec : ComplexVec
-    unroll = M
-    R = N % unroll
-
-    _x = (ntuple(i -> x[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...)
-    _y = (ntuple(i -> y[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...)
-  
-    out = fmul((V(_x)), V(_y))
-
-    for i in R+1:unroll:length(x)
-        a = ntuple(k -> x[i + k - 1], Val(unroll))
-        b = ntuple(k -> y[i + k - 1], Val(unroll))
-        out = fmadd((V(a)), V(b), out)
-    end
-    return fhadd(out)
 end

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -1,4 +1,4 @@
-@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, N < 64 ? Val(8) : Val(16))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, N < 128 ? Val(8) : Val(16))
 @inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float32, ComplexF32}} = dot(x, y, N < 64 ? Val(4) : Val(8))
 @inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float64, ComplexF64}} = dot(x, y, N < 64 ? Val(2) : Val(4))
 

--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -1,7 +1,7 @@
-dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, Val(8))
-dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T} = dot(x, y, Val(4))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T <: Union{Float16, ComplexF16}} = dot(x, y, Val(8))
+@inline dot(x::NTuple{N, T}, y::NTuple{N, T}) where {N, T} = dot(x, y, Val(4))
 
-function dot(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
+@inline function dot(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
     V = T <: Real ? Vec : ComplexVec
     unroll = M
     R = N % unroll
@@ -9,12 +9,12 @@ function dot(x::NTuple{N, T}, y::NTuple{N, T}, ::Val{M}) where {N, T, M}
     _x = (ntuple(i -> x[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...)
     _y = (ntuple(i -> y[i], Val(R))..., ntuple(i -> zero(T), Val(unroll-R))...)
   
-    out = fmul(conj(V(_x)), V(_y))
+    out = fmul((V(_x)), V(_y))
 
     for i in R+1:unroll:length(x)
         a = ntuple(k -> x[i + k - 1], Val(unroll))
         b = ntuple(k -> y[i + k - 1], Val(unroll))
-        out = fmadd(conj(V(a)), V(b), out)
+        out = fmadd((V(a)), V(b), out)
     end
     return fhadd(out)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/linearalgebra_test.jl
+++ b/test/linearalgebra_test.jl
@@ -1,0 +1,18 @@
+let 
+    using LinearAlgebra
+
+    for n in (3, 5, 6, 12, 15, 18, 33, 45, 201)
+        x = ntuple(i -> (complex(rand(), rand())), 200)
+        y = ntuple(i -> (complex(rand(), rand())), 200)
+
+        @test LinearAlgebra.dot(x, y) ≈ SIMDMath.dot(x, y)
+        @test LinearAlgebra.dot(ComplexF32.(x), ComplexF32.(y)) ≈ SIMDMath.dot(ComplexF32.(x), ComplexF32.(y))
+        @test LinearAlgebra.dot(ComplexF16.(x), ComplexF16.(y)) ≈ SIMDMath.dot(ComplexF16.(x), ComplexF16.(y))
+
+        @test LinearAlgebra.dot(real.(x), real.(y)) ≈ SIMDMath.dot(real.(x), real.(y))
+        @test LinearAlgebra.dot(Float32.(real.(x)), Float32.(real.(y))) ≈ SIMDMath.dot(Float32.(real.(x)), Float32.(real.(y)))
+        @test LinearAlgebra.dot(Float16.(real.(x)), Float16.(real.(y))) ≈ SIMDMath.dot(Float16.(real.(x)), Float16.(real.(y)))
+
+    end
+    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Test
 @time @testset "instrinsics" include("intrinsics_test.jl")
 @time @testset "complex" include("complex_test.jl")
 @time @testset "horner" include("horner_test.jl")
+@time @testset "linearalgebra" include("linearalgebra_test.jl")


### PR DESCRIPTION
It might be possible to improve the complex multiply add by combining the operations into more fused mulitiply adds of real vectors..

```julia
# old version
julia> @code_native SIMDMath.fmadd(ComplexVec{2, Float64}((1.2, 1.3), (1.1, 1.5)), SIMDMath.ComplexVec{2, Float64}((1.2, 1.3), (1.5, 1.9)), SIMDMath.ComplexVec{2, Float64}((1.2, 1.3), (1.5, 1.9)))
	.section	__TEXT,__text,regular,pure_instructions
	.build_version macos, 11, 0
	.globl	_julia_fmadd_4686               ; -- Begin function julia_fmadd_4686
	.p2align	2
_julia_fmadd_4686:                      ; @julia_fmadd_4686
; ┌ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:64 within `fmadd`
	.cfi_startproc
; %bb.0:                                ; %top
; │┌ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:14 within `fmul` @ none:0
; ││┌ @ none within `macro expansion`
	ldp	q1, q0, [x0]
	ldp	q3, q2, [x1]
	fmul	v4.2d, v0.2d, v2.2d
; ││└
; ││ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:14 within `fmul`
; ││┌ @ none within `fmsub`
; │││┌ @ none within `macro expansion`
	fneg	v4.2d, v4.2d
	fmla	v4.2d, v3.2d, v1.2d
; ││└└
; ││ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:15 within `fmul`
; ││┌ @ none within `fmadd`
; │││┌ @ none within `macro expansion`
	fmul	v1.2d, v1.2d, v2.2d
	fmla	v1.2d, v3.2d, v0.2d
; │└└└
; │┌ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:30 within `fadd` @ none:0
; ││┌ @ none within `macro expansion`
	ldp	q0, q2, [x2]
	fadd	v0.2d, v4.2d, v0.2d
; ││└
; ││ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:31 within `fadd` @ none:0
; ││┌ @ none within `macro expansion`
	fadd	v1.2d, v1.2d, v2.2d
; │└└
	stp	q0, q1, [x8]
	ret
	.cfi_endproc
; └
                                        ; -- End function
.subsections_via_symbols

```

```julia
julia> @code_native SIMDMath.fmadd(ComplexVec{2, Float64}((1.2, 1.3), (1.1, 1.5)), SIMDMath.ComplexVec{2, Float64}((1.2, 1.3), (1.5, 1.9)), SIMDMath.ComplexVec{2, Float64}((1.2, 1.3), (1.5, 1.9)))
	.section	__TEXT,__text,regular,pure_instructions
	.build_version macos, 11, 0
	.globl	_julia_fmadd_4636               ; -- Begin function julia_fmadd_4636
	.p2align	2
_julia_fmadd_4636:                      ; @julia_fmadd_4636
; ┌ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:66 within `fmadd`
	.cfi_startproc
; %bb.0:                                ; %top
; │ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:67 within `fmadd` @ none:0
; │┌ @ none within `macro expansion`
	ldp	q0, q1, [x1]
	ldp	q2, q3, [x2]
	ldp	q4, q5, [x0]
	fmla	v2.2d, v0.2d, v4.2d
; │└
; │ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:68 within `fmadd` @ none:0
; │┌ @ none within `macro expansion`
	fmla	v3.2d, v1.2d, v4.2d
; │└
; │ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:69 within `fmadd` @ none:0
; │┌ @ none within `macro expansion`
	fmla	v3.2d, v0.2d, v5.2d
; │└
; │ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:70 within `fmadd`
; │┌ @ none within `fnmadd`
; ││┌ @ none within `macro expansion`
	fmls	v2.2d, v1.2d, v5.2d
; │└└
; │ @ /Users/michaelhelton/Documents/Code/repos/SIMDMath.jl/src/complex.jl:71 within `fmadd`
	stp	q2, q3, [x8]
	ret
	.cfi_endproc
```

The native code looks simpler but both are quite fast. Will need some better benchmarks. 